### PR TITLE
Add custom vault path and various fixes

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -25,6 +25,10 @@ KafkaServer {
 };
 ```
 
+If the user name is part of the path, you can provide a `{username}` placeholder which will be replaced by the current user name at runtime.
+
+e.g. `root/{username}/secret`
+
 ## Configuration
 Enable SASL/PLAIN and configure the custom `CallbackHandler`
 - Plain SASL config. See [this](https://docs.confluent.io/current/kafka/authentication_sasl/authentication_sasl_plain.html#configuration) for more options
@@ -52,7 +56,7 @@ username=admin
 password=secretpassword
 ```
 
-For users create entries under `users_path/{user}` with an entry `passoword=secret-client-password`
+For users create entries under `users_path/{user}` with an entry `password=secret-client-password`
 
 - Start the service passing the jaas file as `-Djava.security.auth.login.config=PATH_TO_JAAS_FILE`
 
@@ -60,8 +64,11 @@ For users create entries under `users_path/{user}` with an entry `passoword=secr
 There are few configuration options available through environment variables as follow:
 
 ```bash
+KAFKA_VAULT_USER_ENTRY_KEY=user # Optional. Overrides the name of the key in the secrets map (Default is `username`)
 CACHE_VAULT="true" # When true will enable cache data from vault. Defaults to false.
-VAULT_CACHE_TTL_MIN=5 # Optional, defaults to 2 min when  `CACHE_VAULT` is enabled.
+VAULT_CACHE_TTL_MIN=5 # Optional, defaults to 5 min when  `CACHE_VAULT` is enabled.
+VAULT_ERROR_CACHE_TTL_MIN=5 # Optional, default to 5 minutes when `CACHE_VAULT` is enabled. Prevents to retry a call for n minutes if a query failed (circuit-breaker like)
+
 ```
 
 ## Client Configuration

--- a/src/main/java/com/ultimatesoftware/dataplatform/vaultjca/VaultAuthenticationLoginCallbackHandler.java
+++ b/src/main/java/com/ultimatesoftware/dataplatform/vaultjca/VaultAuthenticationLoginCallbackHandler.java
@@ -112,7 +112,6 @@ public class VaultAuthenticationLoginCallbackHandler implements AuthenticateCall
       }
 
       if (callback instanceof PlainAuthenticateCallback) {
-        log.info("Handling callback for PlainAuth {}", ((PlainAuthenticateCallback) callback).password());
         PlainAuthenticateCallback plainCallback = (PlainAuthenticateCallback) callback;
         plainCallback.authenticated(authenticateWithVault(username, plainCallback.password()));
         continue;

--- a/src/main/java/com/ultimatesoftware/dataplatform/vaultjca/VaultAuthenticationLoginCallbackHandler.java
+++ b/src/main/java/com/ultimatesoftware/dataplatform/vaultjca/VaultAuthenticationLoginCallbackHandler.java
@@ -1,6 +1,7 @@
 package com.ultimatesoftware.dataplatform.vaultjca;
 
 import static com.ultimatesoftware.dataplatform.vaultjca.VaultLoginModule.ENV_CACHE_VAULT;
+import static com.ultimatesoftware.dataplatform.vaultjca.VaultLoginModule.USERNAME_KEY;
 
 import com.ultimatesoftware.dataplatform.vaultjca.services.CacheDecoratorVaultService;
 import com.ultimatesoftware.dataplatform.vaultjca.services.DefaultVaultService;
@@ -51,102 +52,106 @@ import java.util.Map;
  */
 // https://strimzi.io/2018/11/16/using-vault-with-strimzi.html
 public class VaultAuthenticationLoginCallbackHandler implements AuthenticateCallbackHandler {
-  private static final Logger log = LoggerFactory.getLogger(VaultAuthenticationLoginCallbackHandler.class);
-  static final String USERS_PATH = "users_path";
-  static final String ADMIN_PATH = "admin_path";
-  static final String PASSWORD_MAP_ENTRY_KEY = "password";
+    private static final Logger log = LoggerFactory.getLogger(VaultAuthenticationLoginCallbackHandler.class);
+    static final String USERS_PATH = "users_path";
+    static final String ADMIN_PATH = "admin_path";
+    static final String PASSWORD_MAP_ENTRY_KEY = "password";
+    static final String USER_MAP_ENTRY_KEY = "username";
 
-  private final VaultService vaultService;
-  private String usersPathVault;
-  private String adminPathVault;
+    public static final String USERNAME_TEMPLATE_FRAGMENT = "{username}";
 
-  public VaultAuthenticationLoginCallbackHandler() {
-    if (System.getenv(ENV_CACHE_VAULT) != null && System.getenv(ENV_CACHE_VAULT).equalsIgnoreCase("true")){
-      log.debug("Cache vault enabled");
-      vaultService = new CacheDecoratorVaultService(new DefaultVaultService());
-    }
-    else {
-      vaultService = new DefaultVaultService();
-    }
-  }
+    private final VaultService vaultService;
+    private String usersPathVault;
+    private String adminPathVault;
+    private String userMapEntryKey;
 
-  // for testing
-  protected VaultAuthenticationLoginCallbackHandler(VaultService vaultService) {
-    this.vaultService = vaultService;
-  }
-
-  @Override
-  public void configure(Map<String, ?> configs, String saslMechanism, List<AppConfigurationEntry> jaasConfigEntries) {
-    // Loading vault path from jaas config
-    adminPathVault = JaasContext.configEntryOption(jaasConfigEntries, ADMIN_PATH, VaultLoginModule.class.getName());
-    usersPathVault = JaasContext.configEntryOption(jaasConfigEntries, USERS_PATH, VaultLoginModule.class.getName());
-
-    log.info("usersPathVault = {}", usersPathVault);
-    if (usersPathVault == null || usersPathVault.isEmpty()) {
-      throw new RuntimeException(String.format("Jaas file needs an entry %s to the path in vault where the users reside", USERS_PATH));
-    }
-    if (adminPathVault == null || adminPathVault.isEmpty()) {
-      throw new RuntimeException(String.format("Jaas file needs an entry %s to the path in vault where the admin credentials reside", ADMIN_PATH));
-    }
-  }
-
-  @Override
-  public void close() {
-    log.debug("Close called");
-  }
-
-  /**
-   * Handles callback to Vault, expects a {@link NameCallback} with the username and a {@link PlainAuthenticateCallback} with the password.
-   * @param callbacks Callback array with NameCallback and PlainAuthenticateCallback
-   * @throws UnsupportedCallbackException thrown when callbacks are not of either type expected.
-   * @see CallbackHandler#handle(javax.security.auth.callback.Callback[])
-   */
-  @Override
-  public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
-    String username = null;
-    for (Callback callback : callbacks) {
-      if (callback instanceof NameCallback) {
-        username = ((NameCallback) callback).getDefaultName();
-        log.info("Handling callback for NameCallback {}", username);
-        continue;
-      }
-
-      if (callback instanceof PlainAuthenticateCallback) {
-        PlainAuthenticateCallback plainCallback = (PlainAuthenticateCallback) callback;
-        plainCallback.authenticated(authenticateWithVault(username, plainCallback.password()));
-        continue;
-      }
-
-      throw new UnsupportedCallbackException(callback);
-    }
-  }
-
-  private boolean isTemplatedPath(String path) {
-    return path.contains("{username}");
-  }
-
-  private boolean authenticateWithVault(String username, char[] password) {
-    if (username == null) {
-      return false;
+    public VaultAuthenticationLoginCallbackHandler() {
+        if (System.getenv(ENV_CACHE_VAULT) != null && System.getenv(ENV_CACHE_VAULT).equalsIgnoreCase("true")) {
+            log.debug("Cache vault enabled");
+            vaultService = new CacheDecoratorVaultService(new DefaultVaultService());
+        } else {
+            vaultService = new DefaultVaultService();
+        }
+        String fromEnv = System.getenv("KAFKA_VAULT_USER_ENTRY_KEY");
+        userMapEntryKey = fromEnv == null ? USER_MAP_ENTRY_KEY : fromEnv;
     }
 
-
-    String userRenderedPath = isTemplatedPath(usersPathVault) ?  usersPathVault.replace("{username}", username)
-                                                              : String.format("%s/%s", usersPathVault, username);
-    String adminRenderedPath = isTemplatedPath(adminPathVault) ? adminPathVault.replace("{username}", username)
-                                                              : adminPathVault;
-
-    String pathVault = username.equals("admin") ? adminRenderedPath : userRenderedPath;
-    log.info("Trying authentication for {} in path {}", username, pathVault);
-    Map<String, String> usersMap = vaultService.getSecret(pathVault);
-    if (usersMap.size() == 0) {
-      return false;
-    }
-    if (username.equals("admin")) {
-      return usersMap.get("username").equals(username) && Arrays.equals(usersMap.get(PASSWORD_MAP_ENTRY_KEY).toCharArray(), password);
+    // for testing
+    protected VaultAuthenticationLoginCallbackHandler(VaultService vaultService) {
+        this.vaultService = vaultService;
     }
 
-    log.info("Password match {}", Arrays.equals(usersMap.get(PASSWORD_MAP_ENTRY_KEY).toCharArray(), password));
-    return Arrays.equals(usersMap.get(PASSWORD_MAP_ENTRY_KEY).toCharArray(), password);
-  }
+    @Override
+    public void configure(Map<String, ?> configs, String saslMechanism, List<AppConfigurationEntry> jaasConfigEntries) {
+        // Loading vault path from jaas config
+        adminPathVault = JaasContext.configEntryOption(jaasConfigEntries, ADMIN_PATH, VaultLoginModule.class.getName());
+        usersPathVault = JaasContext.configEntryOption(jaasConfigEntries, USERS_PATH, VaultLoginModule.class.getName());
+
+        log.info("usersPathVault = {}", usersPathVault);
+        if (usersPathVault == null || usersPathVault.isEmpty()) {
+            throw new RuntimeException(String.format("Jaas file needs an entry %s to the path in vault where the users reside", USERS_PATH));
+        }
+        if (adminPathVault == null || adminPathVault.isEmpty()) {
+            throw new RuntimeException(String.format("Jaas file needs an entry %s to the path in vault where the admin credentials reside", ADMIN_PATH));
+        }
+    }
+
+    @Override
+    public void close() {
+        log.debug("Close called");
+    }
+
+    /**
+     * Handles callback to Vault, expects a {@link NameCallback} with the username and a {@link PlainAuthenticateCallback} with the password.
+     *
+     * @param callbacks Callback array with NameCallback and PlainAuthenticateCallback
+     * @throws UnsupportedCallbackException thrown when callbacks are not of either type expected.
+     * @see CallbackHandler#handle(javax.security.auth.callback.Callback[])
+     */
+    @Override
+    public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
+        String username = null;
+        for (Callback callback : callbacks) {
+            if (callback instanceof NameCallback) {
+                username = ((NameCallback) callback).getDefaultName();
+                log.debug("Handling callback for NameCallback {}", username);
+                continue;
+            }
+
+            if (callback instanceof PlainAuthenticateCallback) {
+                PlainAuthenticateCallback plainCallback = (PlainAuthenticateCallback) callback;
+                plainCallback.authenticated(authenticateWithVault(username, plainCallback.password()));
+                continue;
+            }
+
+            throw new UnsupportedCallbackException(callback);
+        }
+    }
+
+    private boolean isTemplatedPath(String path) {
+        return path.contains(USERNAME_TEMPLATE_FRAGMENT);
+    }
+
+    private boolean authenticateWithVault(String username, char[] password) {
+        if (username == null) {
+            return false;
+        }
+
+        String userRenderedPath = isTemplatedPath(usersPathVault) ? usersPathVault.replace(USERNAME_TEMPLATE_FRAGMENT, username)
+                : String.format("%s/%s", usersPathVault, username);
+        String adminRenderedPath = isTemplatedPath(adminPathVault) ? adminPathVault.replace(USERNAME_TEMPLATE_FRAGMENT, username)
+                : adminPathVault;
+
+        String pathVault = username.equals("admin") ? adminRenderedPath : userRenderedPath;
+        log.debug("Trying authentication for {} in path {}", username, pathVault);
+        Map<String, String> usersMap = vaultService.getSecret(pathVault);
+        if (usersMap.size() == 0) {
+            return false;
+        }
+        if (username.equals("admin")) {
+            return usersMap.get(userMapEntryKey).equals(username) && Arrays.equals(usersMap.get(PASSWORD_MAP_ENTRY_KEY).toCharArray(), password);
+        }
+
+        return Arrays.equals(usersMap.get(PASSWORD_MAP_ENTRY_KEY).toCharArray(), password);
+    }
 }

--- a/src/main/java/com/ultimatesoftware/dataplatform/vaultjca/VaultAuthenticationLoginCallbackHandler.java
+++ b/src/main/java/com/ultimatesoftware/dataplatform/vaultjca/VaultAuthenticationLoginCallbackHandler.java
@@ -72,13 +72,22 @@ public class VaultAuthenticationLoginCallbackHandler implements AuthenticateCall
         } else {
             vaultService = new DefaultVaultService();
         }
-        String fromEnv = System.getenv("KAFKA_VAULT_USER_ENTRY_KEY");
-        userMapEntryKey = fromEnv == null ? USER_MAP_ENTRY_KEY : fromEnv;
+        initMapKeys(null);
     }
 
     // for testing
-    protected VaultAuthenticationLoginCallbackHandler(VaultService vaultService) {
+    protected VaultAuthenticationLoginCallbackHandler(VaultService vaultService, String userMapKey) {
         this.vaultService = vaultService;
+        initMapKeys(userMapKey);
+    }
+
+    void initMapKeys(String userMapKey) {
+        if (userMapKey != null) {
+            userMapEntryKey = userMapKey;
+        } else {
+            String fromEnv = System.getenv("KAFKA_VAULT_USER_ENTRY_KEY");
+            userMapEntryKey = fromEnv == null ? USER_MAP_ENTRY_KEY : fromEnv;
+        }
     }
 
     @Override

--- a/src/main/java/com/ultimatesoftware/dataplatform/vaultjca/VaultLoginModule.java
+++ b/src/main/java/com/ultimatesoftware/dataplatform/vaultjca/VaultLoginModule.java
@@ -43,7 +43,7 @@ public class VaultLoginModule implements LoginModule {
 
   public VaultLoginModule() {
     if (System.getenv(ENV_CACHE_VAULT) != null && System.getenv(ENV_CACHE_VAULT).equalsIgnoreCase("true")) {
-      log.debug("Cache vault enabled");
+      log.info("Cache vault enabled");
       vaultService = new CacheDecoratorVaultService(new DefaultVaultService());
     } else {
       vaultService = new DefaultVaultService();

--- a/src/main/java/com/ultimatesoftware/dataplatform/vaultjca/services/CacheDecoratorVaultService.java
+++ b/src/main/java/com/ultimatesoftware/dataplatform/vaultjca/services/CacheDecoratorVaultService.java
@@ -45,8 +45,8 @@ public class CacheDecoratorVaultService implements VaultService {
             .maximumSize(500)
             .expireAfterWrite(errorCacheTtl, TimeUnit.MINUTES)
             .build();
-    log.debug("Cache initialized with TTL {}", cacheTtl);
-    log.debug("Error cache initialized with TTL {}", errorCacheTtl);
+    log.info("Cache initialized with TTL {}", cacheTtl);
+    log.info("Error cache initialized with TTL {}", errorCacheTtl);
   }
 
   @Override

--- a/src/main/java/com/ultimatesoftware/dataplatform/vaultjca/services/CacheDecoratorVaultService.java
+++ b/src/main/java/com/ultimatesoftware/dataplatform/vaultjca/services/CacheDecoratorVaultService.java
@@ -3,6 +3,8 @@ package com.ultimatesoftware.dataplatform.vaultjca.services;
 import com.google.common.base.Preconditions;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
+
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -15,31 +17,50 @@ import org.slf4j.LoggerFactory;
  *
  * <p>Keeps an in memory a maximum of 100 entries that expire after 2 Min by default or
  * the user can set its own value using an environment variable VAULT_CACHE_TTL_MIN.</p>
+ *
+ * <p>Also implements a poor-man circuit breaker on a path by path basis so as not to flood Vault
+ * with queries if a non-existent user is queried over and over again.</p>
  */
 public class CacheDecoratorVaultService implements VaultService {
 
   private static final Logger log = LoggerFactory.getLogger(CacheDecoratorVaultService.class);
   private static final String VAULT_CACHE_TTL_MIN = "VAULT_CACHE_TTL_MIN";
+  private static final String VAULT_ERROR_CACHE_TTL_MIN = "VAULT_ERROR_CACHE_TTL_MIN";
   protected final Cache<String, Map<String, String>> cache;
+  protected final Cache<String, Boolean> errorCache;
   private final VaultService vaultService;
+
+  private final Map<String,String> EMPTY_MAP = new HashMap<>();
 
   public CacheDecoratorVaultService(VaultService vaultService) {
     Preconditions.checkArgument(!(vaultService instanceof CacheDecoratorVaultService), "Use any other implementation of VaultService as a delegator");
     long cacheTtl = (System.getenv(VAULT_CACHE_TTL_MIN) != null) ? Long.parseLong(System.getenv(VAULT_CACHE_TTL_MIN)) : 2;
+    long errorCacheTtl = (System.getenv(VAULT_ERROR_CACHE_TTL_MIN) != null) ? Long.parseLong(System.getenv(VAULT_ERROR_CACHE_TTL_MIN)) : 5;
     this.vaultService = vaultService;
     this.cache = CacheBuilder.newBuilder()
         .maximumSize(100)
-        .expireAfterAccess(cacheTtl, TimeUnit.MINUTES)
+        .expireAfterWrite(cacheTtl, TimeUnit.MINUTES) // We want to check the actual pwd in Vault from time to time.
         .build();
+    this.errorCache = CacheBuilder.newBuilder()
+            .maximumSize(500)
+            .expireAfterWrite(errorCacheTtl, TimeUnit.MINUTES)
+            .build();
     log.debug("Cache initialized with TTL {}", cacheTtl);
+    log.debug("Error cache initialized with TTL {}", errorCacheTtl);
   }
 
   @Override
   public Map<String, String> getSecret(String path) {
     try {
       log.debug("Hit count {}, miss count {}, size {}", cache.stats().hitCount(), cache.stats().missCount(), cache.size());
+      if(errorCache.getIfPresent(path) != null){
+        log.info("Path {} had error-ed less than {} minutes ago. Will retry then.");
+        return EMPTY_MAP;
+      }
       return cache.get(path, () -> vaultService.getSecret(path));
     } catch (ExecutionException e) {
+      //TODO: Add a global circuit breaker for Vault if the error is not tied to a specific path
+      errorCache.put(path, true); // Won't retry the same user path for a while
       throw new RuntimeException(e);
     }
   }

--- a/src/test/java/com/ultimatesoftware/dataplatform/vaultjca/VaultAuthenticationLoginCallbackHandlerTest.java
+++ b/src/test/java/com/ultimatesoftware/dataplatform/vaultjca/VaultAuthenticationLoginCallbackHandlerTest.java
@@ -86,6 +86,26 @@ public class VaultAuthenticationLoginCallbackHandlerTest {
   }
 
   @Test
+  public void shouldHandleTemplatedAdminLogin() throws Exception {
+    callbackHandler.configure(Collections.EMPTY_MAP, SASL_MECHANISM, jaasConfigEntries);
+
+    Callback[] callbacks = new Callback[2];
+    callbacks[0] = new NameCallback("username", "admin");
+    callbacks[1] = new PlainAuthenticateCallback("adminpwd".toCharArray());
+
+    Map<String, String> adminCreds = new HashMap<>();
+    adminCreds.put("username", "admin");
+    adminCreds.put(VaultAuthenticationLoginCallbackHandler.PASSWORD_MAP_ENTRY_KEY, "adminpwd");
+
+    // when(vaultService.getSecret(ArgumentMatchers.eq(VAULT_KAFKA_TEMPLATED_ADMIN_PATH))).thenReturn(adminCreds);
+
+    callbackHandler.handle(callbacks);
+    assertThat(((PlainAuthenticateCallback) callbacks[1]).authenticated(), is(true));
+    verify(vaultService).getSecret(ArgumentMatchers.eq(VAULT_KAFKA_ADMIN_PATH));
+    verify(vaultService, never()).getSecret(ArgumentMatchers.eq(VAULT_KAFKA_USERS_PATH));
+  }
+
+  @Test
   public void shouldHandleClientLogin() throws Exception {
     callbackHandler.configure(Collections.EMPTY_MAP, SASL_MECHANISM, jaasConfigEntries);
 

--- a/src/test/java/com/ultimatesoftware/dataplatform/vaultjca/VaultLoginModuleTest.java
+++ b/src/test/java/com/ultimatesoftware/dataplatform/vaultjca/VaultLoginModuleTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.ultimatesoftware.dataplatform.vaultjca.services.VaultService;
+import static com.ultimatesoftware.dataplatform.vaultjca.VaultAuthenticationLoginCallbackHandler.USERNAME_TEMPLATE_FRAGMENT;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -19,12 +20,13 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.mockito.ArgumentMatchers;
 
+
 public class VaultLoginModuleTest {
 
   protected static final String VAULT_KAFKA_ADMIN_PATH = "secrets/kafka/admin";
-  protected static final String VAULT_KAFKA_TEMPLATED_ADMIN_PATH = "kafka/{username}/secret}";
+  protected static final String VAULT_KAFKA_TEMPLATED_ADMIN_PATH = "kafka/" + USERNAME_TEMPLATE_FRAGMENT + "/secret";
   protected static final String VAULT_KAFKA_USERS_PATH = "secrets/kafka/users";
-  protected static final String VAULT_KAFKA_TEMPLATED_USERS_PATH = "kafka/{username}/secret}";
+  protected static final String VAULT_KAFKA_TEMPLATED_USERS_PATH = "kafka/" + USERNAME_TEMPLATE_FRAGMENT + "/secret";
   private static final String ADMIN = "admin";
   private static final String ADMINPWD = "adminpwd";
   private VaultService vaultService = mock(VaultService.class);

--- a/src/test/java/com/ultimatesoftware/dataplatform/vaultjca/VaultLoginModuleTest.java
+++ b/src/test/java/com/ultimatesoftware/dataplatform/vaultjca/VaultLoginModuleTest.java
@@ -22,7 +22,9 @@ import org.mockito.ArgumentMatchers;
 public class VaultLoginModuleTest {
 
   protected static final String VAULT_KAFKA_ADMIN_PATH = "secrets/kafka/admin";
+  protected static final String VAULT_KAFKA_TEMPLATED_ADMIN_PATH = "kafka/{username}/secret}";
   protected static final String VAULT_KAFKA_USERS_PATH = "secrets/kafka/users";
+  protected static final String VAULT_KAFKA_TEMPLATED_USERS_PATH = "kafka/{username}/secret}";
   private static final String ADMIN = "admin";
   private static final String ADMINPWD = "adminpwd";
   private VaultService vaultService = mock(VaultService.class);

--- a/src/test/java/com/ultimatesoftware/dataplatform/vaultjca/services/CacheDecoratorVaultServiceTest.java
+++ b/src/test/java/com/ultimatesoftware/dataplatform/vaultjca/services/CacheDecoratorVaultServiceTest.java
@@ -42,5 +42,15 @@ public class CacheDecoratorVaultServiceTest {
     verify(vaultService, never()).getSecret(eq(path));
   }
 
+  @Test
+  public void shouldCacheMissingEntryError() {
+    int TOTAL_TIMES_CALLED = 1;
+    String path = "no/user/in/this/path";
+    cacheDecoratorVaultService.getSecret(path);
+    verify(vaultService, times(TOTAL_TIMES_CALLED)).getSecret(eq(path));
+    cacheDecoratorVaultService.getSecret(path);
+    verify(vaultService, times(TOTAL_TIMES_CALLED)).getSecret(eq(path));
+  }
+
 }
 


### PR DESCRIPTION
* We can now specify a vault path containing the user name (by specifying `/my/path/{username}/foo`)
* Add option to override the `user` key
* Change cache behavior (only refill TTL on write, not access so non-existing or rotated secrets eventually get fetched in vault proper)
* Added a circuit-breaker like cache to ease on Vault when the API returns errors
* Removed password logging
* Tweaked logging level
