### PR TITLE
Custom vault client impl

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,18 @@
             <version>${guava.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.11.2</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.11.2</version>
+        </dependency>
+
 
         <dependency>
             <groupId>junit</groupId>

--- a/src/main/java/com/ultimatesoftware/dataplatform/vaultjca/services/DefaultVaultService.java
+++ b/src/main/java/com/ultimatesoftware/dataplatform/vaultjca/services/DefaultVaultService.java
@@ -12,11 +12,11 @@ public class DefaultVaultService implements VaultService {
   private static final Logger log = LoggerFactory.getLogger(DefaultVaultService.class);
   private static Integer KV_VERSION = 2;
 
-  private final DirtSimpleVaultClient vault;
+  private final SimpleVaultClient vault;
 
   public DefaultVaultService() {
     try {
-      this.vault = new DirtSimpleVaultClient(new VaultConfig().build(), KV_VERSION);
+      this.vault = new SimpleVaultClient(new VaultConfig().build(), KV_VERSION);
     } catch (VaultException e) {
       log.error("Error creating Vault service", e);
       throw new RuntimeException(e);
@@ -25,7 +25,7 @@ public class DefaultVaultService implements VaultService {
 
   protected DefaultVaultService(String vaultAddr, String token) {
     try {
-      this.vault = new DirtSimpleVaultClient(new VaultConfig().address(vaultAddr).token(token).build(), KV_VERSION);
+      this.vault = new SimpleVaultClient(new VaultConfig().address(vaultAddr).token(token).build(), KV_VERSION);
     } catch (VaultException e) {
       log.error("Error creating Vault service", e);
       throw new RuntimeException(e);

--- a/src/main/java/com/ultimatesoftware/dataplatform/vaultjca/services/DefaultVaultService.java
+++ b/src/main/java/com/ultimatesoftware/dataplatform/vaultjca/services/DefaultVaultService.java
@@ -1,29 +1,22 @@
 package com.ultimatesoftware.dataplatform.vaultjca.services;
 
-import com.bettercloud.vault.Vault;
 import com.bettercloud.vault.VaultConfig;
 import com.bettercloud.vault.VaultException;
-
-import java.nio.charset.StandardCharsets;
-import java.util.Collections;
-import java.util.Map;
-
-import com.bettercloud.vault.response.AuthResponse;
-import com.bettercloud.vault.response.LogicalResponse;
-import com.bettercloud.vault.response.VaultResponse;
-import com.bettercloud.vault.rest.Rest;
-import com.bettercloud.vault.rest.RestResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collections;
+import java.util.Map;
+
 public class DefaultVaultService implements VaultService {
   private static final Logger log = LoggerFactory.getLogger(DefaultVaultService.class);
+  private static Integer KV_VERSION = 2;
 
-  private final Vault vault;
+  private final DirtSimpleVaultClient vault;
 
   public DefaultVaultService() {
     try {
-      this.vault = new Vault(new VaultConfig().build());
+      this.vault = new DirtSimpleVaultClient(new VaultConfig().build(), KV_VERSION);
     } catch (VaultException e) {
       log.error("Error creating Vault service", e);
       throw new RuntimeException(e);
@@ -32,9 +25,9 @@ public class DefaultVaultService implements VaultService {
 
   protected DefaultVaultService(String vaultAddr, String token) {
     try {
-      this.vault = new Vault(new VaultConfig().address(vaultAddr).token(token).build());
+      this.vault = new DirtSimpleVaultClient(new VaultConfig().address(vaultAddr).token(token).build(), KV_VERSION);
     } catch (VaultException e) {
-      log.error("Error building Vault", e);
+      log.error("Error creating Vault service", e);
       throw new RuntimeException(e);
     }
   }
@@ -42,13 +35,9 @@ public class DefaultVaultService implements VaultService {
   @Override
   public Map<String, String> getSecret(String path) {
     try {
-      LogicalResponse resp = vault.logical().read(path);
-      RestResponse rest = resp.getRestResponse();
-      if (rest.getStatus() != 200){ // Status codes in the 4xx range are not treated as exceptions by the driver...
-        log.warn("Error contacting vault. Status: {} Message was: {}", rest.getStatus(), new String(rest.getBody(), StandardCharsets.UTF_8));
-      }
+      Map<String, String> res = vault.read(path);
+      return res;
 
-      return resp.getData();
     } catch (VaultException e) {
       if (e.getHttpStatusCode() == 404) {
         return Collections.EMPTY_MAP;
@@ -59,10 +48,6 @@ public class DefaultVaultService implements VaultService {
 
   @Override
   public void writeSecret(String path, Map<String, String> value) {
-    try {
-      vault.logical().write(path, Collections.unmodifiableMap(value));
-    } catch (VaultException e) {
-      throw new RuntimeException(e);
-    }
+      vault.write(path, Collections.unmodifiableMap(value));
   }
 }

--- a/src/main/java/com/ultimatesoftware/dataplatform/vaultjca/services/DirtSimpleVaultClient.java
+++ b/src/main/java/com/ultimatesoftware/dataplatform/vaultjca/services/DirtSimpleVaultClient.java
@@ -1,0 +1,93 @@
+package com.ultimatesoftware.dataplatform.vaultjca.services;
+
+import com.bettercloud.vault.VaultConfig;
+import com.bettercloud.vault.VaultException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+
+public class DirtSimpleVaultClient {
+
+    String token;
+    String vaultAddr;
+    Map<String,String> headers;
+    Integer version;
+
+    ObjectMapper mapper;
+
+    private static final Logger log = LoggerFactory.getLogger(DirtSimpleVaultClient.class);
+
+    private static final Map<String, String> EMPTY_MAP = Collections.unmodifiableMap(new HashMap<>());
+
+    public DirtSimpleVaultClient(VaultConfig conf, int version){
+        token = conf.getToken();
+        this.version = version;
+        vaultAddr = conf.getAddress();
+        if (conf.getAddress() == null){
+            String addr = System.getenv("VAULT_ADDR");
+            if (addr == null) {
+                throw new RuntimeException("No Vault address specified and VAULT_ADDR env var is empty.");
+            }
+            vaultAddr = addr;
+        }
+        headers = new HashMap<>();
+        headers.put("X-Vault-Request", "true");
+
+        if (token != null){
+            headers.put("X-Vault-Token", token);
+        }
+        mapper = new ObjectMapper();
+    }
+
+    public Map<String, String> extractMap(InputStream payload){
+        // Only supports Read Secret (https://www.vaultproject.io/api/secret/kv/kv-v2.html)
+        try {
+            Map<String, Object> jsonObject = mapper.readValue(payload, new TypeReference<Map<String,Object>>(){});
+            Map<String, Object> data = (Map<String, Object>)(jsonObject.get("data")); //V2
+            Map<String, String> result = (Map<String, String>)(data.get("data"));
+
+            return result;
+
+        } catch (Exception ignored) {
+            return EMPTY_MAP;
+        }
+    }
+
+    public Map<String, String> read(String path) throws VaultException {
+        String adjustedPath = path.replaceAll("^kv/", "kv/data/");
+
+        try {
+            URL url = new URL(vaultAddr + "/v1/" + adjustedPath);
+            HttpURLConnection cn = (HttpURLConnection)url.openConnection();
+            for(Map.Entry<String,String> kv:headers.entrySet()){
+                cn.setRequestProperty(kv.getKey(), kv.getValue());
+            }
+            InputStream resp = cn.getInputStream();
+            int status = cn.getResponseCode();
+            if (status == 200) {
+                return extractMap(resp);
+            }
+            if (status == 404){
+                log.info("Path {} not found", path);
+                return EMPTY_MAP;
+            }
+        } catch (IOException e) {
+            throw new VaultException(e);
+        }
+        return EMPTY_MAP;
+    }
+
+    public void write(String path, Map<String, String> unmodifiableMap) {
+        throw new UnsupportedOperationException("Write not supported by this implementation.");
+    }
+}

--- a/src/main/java/com/ultimatesoftware/dataplatform/vaultjca/services/SimpleVaultClient.java
+++ b/src/main/java/com/ultimatesoftware/dataplatform/vaultjca/services/SimpleVaultClient.java
@@ -16,7 +16,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 
-public class DirtSimpleVaultClient {
+public class SimpleVaultClient {
 
     String token;
     String vaultAddr;
@@ -25,11 +25,11 @@ public class DirtSimpleVaultClient {
 
     ObjectMapper mapper;
 
-    private static final Logger log = LoggerFactory.getLogger(DirtSimpleVaultClient.class);
+    private static final Logger log = LoggerFactory.getLogger(SimpleVaultClient.class);
 
     private static final Map<String, String> EMPTY_MAP = Collections.unmodifiableMap(new HashMap<>());
 
-    public DirtSimpleVaultClient(VaultConfig conf, int version){
+    public SimpleVaultClient(VaultConfig conf, int version){
         token = conf.getToken();
         this.version = version;
         vaultAddr = conf.getAddress();

--- a/src/test/java/com/ultimatesoftware/dataplatform/vaultjca/VaultConnectionTest.java
+++ b/src/test/java/com/ultimatesoftware/dataplatform/vaultjca/VaultConnectionTest.java
@@ -2,7 +2,7 @@ package com.ultimatesoftware.dataplatform.vaultjca;
 
 import com.bettercloud.vault.VaultConfig;
 import com.bettercloud.vault.VaultException;
-import com.ultimatesoftware.dataplatform.vaultjca.services.DirtSimpleVaultClient;
+import com.ultimatesoftware.dataplatform.vaultjca.services.SimpleVaultClient;
 import org.junit.Ignore;
 import org.junit.Test;
 import static org.junit.Assert.assertThat;
@@ -20,7 +20,7 @@ public class VaultConnectionTest {
                 .token("XXXX")
                 .build();
 
-        DirtSimpleVaultClient vault = new DirtSimpleVaultClient(conf, 2);
+        SimpleVaultClient vault = new SimpleVaultClient(conf, 2);
         Map<String, String> res = vault.read("kv/kafka/kafka-test-1/k8s/__internal/admin/secrets");
         assertThat(res.get("user"), is("admin"));
     }

--- a/src/test/java/com/ultimatesoftware/dataplatform/vaultjca/VaultConnectionTest.java
+++ b/src/test/java/com/ultimatesoftware/dataplatform/vaultjca/VaultConnectionTest.java
@@ -1,0 +1,28 @@
+package com.ultimatesoftware.dataplatform.vaultjca;
+
+import com.bettercloud.vault.VaultConfig;
+import com.bettercloud.vault.VaultException;
+import com.ultimatesoftware.dataplatform.vaultjca.services.DirtSimpleVaultClient;
+import org.junit.Ignore;
+import org.junit.Test;
+import static org.junit.Assert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+
+
+import java.util.Map;
+
+public class VaultConnectionTest {
+    @Test
+    @Ignore
+    public void TestConnectionAndSerializationWorks() throws VaultException {
+        VaultConfig conf = new VaultConfig()
+                .address("XXXX")
+                .token("XXXX")
+                .build();
+
+        DirtSimpleVaultClient vault = new DirtSimpleVaultClient(conf, 2);
+        Map<String, String> res = vault.read("kv/kafka/kafka-test-1/k8s/__internal/admin/secrets");
+        assertThat(res.get("user"), is("admin"));
+    }
+
+}

--- a/src/test/java/com/ultimatesoftware/dataplatform/vaultjca/VaultLoginModuleTest.java
+++ b/src/test/java/com/ultimatesoftware/dataplatform/vaultjca/VaultLoginModuleTest.java
@@ -1,26 +1,25 @@
 package com.ultimatesoftware.dataplatform.vaultjca;
 
+import com.ultimatesoftware.dataplatform.vaultjca.services.VaultService;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.ArgumentMatchers;
+
+import javax.security.auth.Subject;
+import javax.security.auth.callback.CallbackHandler;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+
 import static com.ultimatesoftware.dataplatform.vaultjca.VaultAuthenticationLoginCallbackHandler.*;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-
-import com.ultimatesoftware.dataplatform.vaultjca.services.VaultService;
-
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import javax.security.auth.Subject;
-import javax.security.auth.callback.CallbackHandler;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.mockito.ArgumentMatchers;
-import org.testcontainers.shaded.org.bouncycastle.crypto.tls.UserMappingType;
 
 
 public class VaultLoginModuleTest {


### PR DESCRIPTION
The vault library used by jca-vault [vault-java-driver](https://github.com/BetterCloud/vault-java-driver) does not send the required headers to Vault `X-Vault-Request: true` Turns out vault does not enforce the header, but Emissary (which we use as a local proxy to vault) does and silently drops any request to vault without that header. We opened an issue in the jca